### PR TITLE
Task1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-router-dom": "^6.0.0-alpha.3",
     "react-scripts": "3.4.3",
     "swr": "^0.3.0",
-    "timeago.js": "^4.0.2"
+    "timeago.js": "^4.0.2",
+    "tz-lookup": "^6.1.25"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,16 +19,23 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { 
+  formatDateTime, 
+  formatDateTimeInTZ, 
+  getTimeZoneFromLatLong 
+} from "../utils/format-date";
+
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
 export default function Launch() {
   let { launchId } = useParams();
   const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
+  const { data: launchPad } = useSpaceX(launch ? '/launchpads/'+launch?.launch_site.site_id : null);
 
   if (error) return <Error />;
   if (!launch) {
@@ -50,7 +57,7 @@ export default function Launch() {
       />
       <Header launch={launch} />
       <Box m={[3, 6]}>
-        <TimeAndLocation launch={launch} />
+        <TimeAndLocation launch={launch} launchPad={launchPad} />
         <RocketInfo launch={launch} />
         <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
           {launch.details}
@@ -113,7 +120,8 @@ function Header({ launch }) {
   );
 }
 
-function TimeAndLocation({ launch }) {
+function TimeAndLocation({ launch, launchPad }) {
+  console.log(launchPad)
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>
@@ -124,7 +132,13 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={"Your time: " + formatDateTime(launch.launch_date_local)}>
+            {launchPad ? formatDateTimeInTZ(launch.launch_date_utc, 
+              getTimeZoneFromLatLong(parseInt(launchPad.location.latitude), 
+                parseInt(launchPad.location.longitude))) : 
+              formatDateTime(launch.launch_date_local)
+              } 
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,5 @@
+import tzLookup from "tz-lookup";
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
@@ -7,14 +9,27 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
+let dateOptions = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  second: "numeric",
+  timeZoneName: "short"
+};
+
 export function formatDateTime(timestamp) {
+  return new Intl.DateTimeFormat("en-US", dateOptions).format(new Date(timestamp));
+}
+
+export function formatDateTimeInTZ(timestamp, timeZone) {
   return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    second: "numeric",
-    timeZoneName: "short",
+    ...dateOptions,
+    timeZone: timeZone
   }).format(new Date(timestamp));
+}
+
+export function getTimeZoneFromLatLong(lat, long) {
+  return tzLookup(lat, long);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10269,6 +10269,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+tz-lookup@^6.1.25:
+  version "6.1.25"
+  resolved "https://registry.yarnpkg.com/tz-lookup/-/tz-lookup-6.1.25.tgz#34d68a7e1ccfcb51f29a9893d2d48e4118d873cd"
+  integrity sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
I couldn't find a way to convert the client's time given by the _launch_ API into the launch site time since no timezone info was provided (or any other info that would make the conversion possible). So, I decided to make an additional API call to 
the _launchpad_ where the launch happened. _launchpad_ provides longitude & latitude which I used to convert into a timezone with [tz-lookup](https://www.npmjs.com/package/tz-lookup). Finally, using the client's time and the launch-site's TZ, I converted the time.

Note: Instead of showing the Spinner while the _launchpad_ call is in progress, I show the client's time as a fallback. That way, if _launchpad_ is slow or unresponsive, the user sees their local time.

